### PR TITLE
Fix undeclared variable

### DIFF
--- a/lib/typecheck/init.lua
+++ b/lib/typecheck/init.lua
@@ -277,7 +277,7 @@ local function checktypespec(expected, actual)
       check = check or expect
 
       -- Does the type of actual check out?
-      ok = checktype(check, actual)
+      local ok = checktype(check, actual)
 
       -- For 'table of things', check all elements are a thing too.
       if ok and contents and type(actual) == 'table' then


### PR DESCRIPTION
I installed 'typecheck' from luarocks on Arch Linux and ran into an issue.

When trying to run the following code:
`local argcheck = require("typecheck").argcheck

local function a(msg, num)
        argcheck("local a.msg", 1, "string", msg)
        print(msg, num)
end

a("Hi")`

I ran into the following error:

`lua: /home/ax/.luarocks/share/lua/5.3/typecheck/init.lua:280: assignment to undeclared variable 'ok'
stack traceback:
        [C]: in function 'error'
        /home/ax/.luarocks/share/lua/5.3/std/strict/init.lua:105: in metamethod '__newindex'
        /home/ax/.luarocks/share/lua/5.3/typecheck/init.lua:280: in function 'typecheck.check'
        /home/ax/.luarocks/share/lua/5.3/typecheck/init.lua:485: in function 'typecheck.argcheck'
        try_check.lua:4: in local 'a'
        try_check.lua:8: in main chunk
        [C]: in ?`

So I made 'ok' local, apparently resolving the problem.